### PR TITLE
TOUR-82: Tour resume button is visible when printing the page

### DIFF
--- a/application-tour-ui/src/main/resources/TourCode/TourJS.xml
+++ b/application-tour-ui/src/main/resources/TourCode/TourJS.xml
@@ -588,6 +588,12 @@ require(['jquery', 'xwiki-meta'], function ($, xm) {
   }
 }
 
+@media print {
+  #tourResumeContainer {
+    display: none;
+  }
+}
+
 #bootstrap_tour_close {
   position: absolute;
   top: 3px;


### PR DESCRIPTION
## PR Changes
* Added necessary style to prevent the button from displaying on prints
## View
A "Ctrl+P" saved to PDF before the PR, we can see the button on the bottom right of the pages.
[TOUR-82beforePR.pdf](https://github.com/xwiki-contrib/application-tour/files/12576336/TOUR-82beforePR.pdf)
A "Ctrl+P" saved to PDF after the PR, we can **not** see the button on the bottom right of the pages.
[TOUR-82afterPR.pdf](https://github.com/xwiki-contrib/application-tour/files/12576338/TOUR-82afterPR.pdf)
